### PR TITLE
Add SSH pre-flight connectivity test

### DIFF
--- a/main.js
+++ b/main.js
@@ -92,6 +92,23 @@
 		return;
 	}
 
+	// Quick SSH connectivity test before proceeding
+	console.log( '::group::SSH connectivity test' );
+	let sshTestShell = sshPass ? 'sshpass' : 'ssh';
+	let sshTestParams = shellParams.split( ' ' ).filter( p => p.length > 0 );
+	let sshTestArgs = sshPass
+		? [ '-e', 'ssh', ...sshTestParams, '-o', 'ConnectTimeout=10', '-o', 'StrictHostKeyChecking=no', remoteTarget, 'echo', 'ssh-ok' ]
+		: [ ...sshTestParams, '-o', 'ConnectTimeout=10', '-o', 'StrictHostKeyChecking=no', remoteTarget, 'echo', 'ssh-ok' ];
+	if ( remotePort ) {
+		sshTestArgs.splice( sshPass ? 2 : 0, 0, '-p', remotePort );
+	}
+	let sshTestCode = await exec.exec( sshTestShell, sshTestArgs, { ignoreReturnCode: true } );
+	console.log( '::endgroup::' );
+	if ( sshTestCode !== 0 ) {
+		core.setFailed( 'SSH connectivity test failed (exit code ' + sshTestCode + '). Check SSH credentials and host accessibility for ' + remoteTarget );
+		process.exit( 1 );
+	}
+
 	if ( consistencyCheck ) {
 		console.log( '::group::Running consistency check.' );
 	} else {


### PR DESCRIPTION
## Summary
- Adds a quick SSH connectivity test (`echo ssh-ok`) before proceeding with the full rsync flow
- If SSH auth or connectivity fails, exits immediately with a clear error message
- Makes SSH failures fail in ~2 seconds instead of going through the full rsync process (~1-3 min)

## Context
The consistency check workflow has a 53% failure rate across 47 repos. Many failures are SSH credential issues (Permission denied, host unreachable). Currently these go through the full rsync flow before failing, wasting 1-3 minutes per run.

The pre-flight test runs right after the sshKey/sshPass validation, before any rsync setup. It uses the same SSH parameters (shell, port, credentials) that rsync would use.

## Test plan
- [ ] Test with a repo that has working SSH credentials — verify normal flow is unaffected
- [ ] Test with a repo that has broken SSH credentials — verify it fails fast with clear error
- [ ] Verify the error message includes the remote target for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)