### PR TITLE
feat: add SSH credential preflight validation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,10 @@ inputs:
     description: "Pass a full path to a script that will be triggered right before the actual rsync command is executed"
     required: false
     default: ''
+  preflight:
+    description: "Validate SSH credentials (key or password) with a test connection before attempting any sync"
+    required: false
+    default: 'true'
 runs:
   using: 'node16'
   main: 'main.js'

--- a/main.js
+++ b/main.js
@@ -22,6 +22,7 @@
 	const sshKey = core.getInput( 'env-key', { required: false } );
 	const sshPass = core.getInput( 'env-pass', { required: false } );
 	const consistencyCheck = core.getInput( 'consistency-check', { required: false } );
+	const preflight = core.getInput( 'preflight', { required: false } );
 
 	let ignoreList = core.getInput( 'force-ignore', { required: false } );
 	if ( ignoreList === 'false' ) {
@@ -120,6 +121,45 @@
 
 	if ( remotePort ) {
 		shellParams.push( '-p ' + remotePort );
+	}
+
+	// Preflight: validate the provided credentials with a cheap test connection
+	// before any rsync/consistency work, so auth failures surface with a clear
+	// message instead of a confusing rsync error mid-deploy.
+	if ( preflight !== 'false' ) {
+		console.log( '::group::Validating SSH credentials.' );
+
+		const preflightParams = shellParams.filter( ( p ) => p !== '' );
+		// Fail fast on connection issues instead of hanging.
+		preflightParams.push( '-o ConnectTimeout=15' );
+		if ( ! sshPass ) {
+			// Key auth: never fall back to an interactive password prompt (would hang).
+			preflightParams.push( '-o BatchMode=yes' );
+		}
+
+		const preflightCommand =
+			shell + ' ' + preflightParams.join( ' ' ) + ' ' + remoteTarget + ' true';
+
+		console.log( preflightCommand );
+
+		const preflightCode = await exec.exec( preflightCommand, [], {
+			ignoreReturnCode: true,
+		} );
+
+		if ( preflightCode != 0 ) {
+			console.log( '::endgroup::' );
+			core.setFailed(
+				'SSH preflight failed: the provided ' +
+					( sshPass ? 'password' : 'SSH key' ) +
+					' was rejected or the host is unreachable (exit code ' +
+					preflightCode +
+					'). Verify the credentials, host, port and that the key is authorized on the target.'
+			);
+			process.exit( preflightCode );
+		}
+
+		console.log( 'SSH credentials validated.' );
+		console.log( '::endgroup::' );
 	}
 
 	var rsync = new Rsync()


### PR DESCRIPTION
## Problem

SSH deployments were failing with confusing rsync errors when credentials were wrong/unauthorized or the host was unreachable. The real cause (auth) was buried in rsync output, and key-auth misconfig could hang on an interactive password prompt.

## Change

Add a **preflight credential check** in `main.js` that runs before any rsync / consistency-check work:

- Runs a cheap `ssh user@host true` using the **same shell, params and port** the deploy itself uses — so it validates the exact credentials in play.
- **Key auth** (`ssh` via ssh-agent): adds `-o BatchMode=yes` → fails fast instead of hanging on a password prompt.
- **Password auth** (`sshpass -e ssh`): skips `BatchMode` (sshpass needs password auth enabled); password rides in the `SSHPASS` env, never logged.
- Adds `-o ConnectTimeout=15` so unreachable hosts fail quickly.
- On failure: `core.setFailed` with a clear message distinguishing key vs password + exit code, then exits.

New `preflight` input (default `'true'`) allows opt-out.

## Notes

- Host key already populated in `known_hosts` by `pre.js` (ssh-keyscan), so no host-key prompt.
- No automated test suite in this repo; validated with `node --check`. Recommend a smoke test on a downstream deploy workflow (one good-cred run, one bad-cred run) before tagging a new major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)