### PR TITLE
feat: add SSH credential preflight validation in pre step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,10 @@ inputs:
     description: "Pass a full path to a script that will be triggered right before the actual rsync command is executed"
     required: false
     default: ''
+  preflight:
+    description: "Validate SSH credentials (key or password) with a test connection in the pre step, on every invocation, before attempting any sync. Set to 'false' to disable."
+    required: false
+    default: 'true'
 runs:
   using: 'node16'
   main: 'main.js'

--- a/pre.js
+++ b/pre.js
@@ -3,42 +3,106 @@
 	const core = require( '@actions/core' );
 	const fs = require( 'fs' );
 
-	if ( core.getInput( 'run-pre', { required: true } ) == 'false' ) {
-		return;
-	}
-
-	await exec.exec( 'mkdir', ['-p', '/home/runner/.ssh'] );
-	await exec.exec( 'touch', ['/home/runner/.ssh/known_hosts'] );
-
 	const remoteHost = core.getInput( 'env-host', { required: false } );
-	if( remoteHost != '' ) {
-		const remotePort = core.getInput( 'env-port', { required: false } );
-		await exec.exec( 'bash', ['-c', 'ssh-keyscan -p "' + remotePort + '" -H "' + remoteHost + '" >> /home/runner/.ssh/known_hosts' ] );
-	}
-
+	const remotePort = core.getInput( 'env-port', { required: false } );
+	const remoteUser = core.getInput( 'env-user', { required: false } );
 	const remoteKey = core.getInput( 'env-key', { required: false } );
-	if( remoteKey != '' ) {
-		const sock = '/tmp/ssh_agent.sock';
-		if( ! fs.existsSync( sock ) ) {
-			core.exportVariable( 'SSH_AUTH_SOCK', sock );
-			process.env['SSH_AUTH_SOCK'] = sock;
-			await exec.exec( 'ssh-agent', ['-a', sock] );
+	const remotePass = core.getInput( 'env-pass', { required: false } );
+	const shellParams = core.getInput( 'ssh-shell-params', { required: false } );
+	const sock = '/tmp/ssh_agent.sock';
+
+	// Credential setup is gated by run-pre: when deploy-ssh is invoked multiple
+	// times in a flow (e.g. consistency-check then push), later invocations pass
+	// run-pre=false to reuse the agent / known_hosts / sshpass left on the runner.
+	if ( core.getInput( 'run-pre', { required: true } ) != 'false' ) {
+		await exec.exec( 'mkdir', ['-p', '/home/runner/.ssh'] );
+		await exec.exec( 'touch', ['/home/runner/.ssh/known_hosts'] );
+
+		if( remoteHost != '' ) {
+			await exec.exec( 'bash', ['-c', 'ssh-keyscan -p "' + remotePort + '" -H "' + remoteHost + '" >> /home/runner/.ssh/known_hosts' ] );
 		}
 
-		var i = 0;
-		var keyPath;
-		do {
-			i++;
-			keyPath = '/home/runner/.ssh/github_actions_' + i;
-		} while	( fs.existsSync( keyPath ) );
+		if( remoteKey != '' ) {
+			if( ! fs.existsSync( sock ) ) {
+				core.exportVariable( 'SSH_AUTH_SOCK', sock );
+				process.env['SSH_AUTH_SOCK'] = sock;
+				await exec.exec( 'ssh-agent', ['-a', sock] );
+			}
 
-		await exec.exec( 'bash', ['-c', 'echo "' + remoteKey + '" > ' + keyPath ] );
-		await exec.exec( 'chmod', ['600', keyPath] );
-		await exec.exec( 'bash', ['-c', 'ssh-add ' + keyPath ] );
+			var i = 0;
+			var keyPath;
+			do {
+				i++;
+				keyPath = '/home/runner/.ssh/github_actions_' + i;
+			} while	( fs.existsSync( keyPath ) );
+
+			await exec.exec( 'bash', ['-c', 'echo "' + remoteKey + '" > ' + keyPath ] );
+			await exec.exec( 'chmod', ['600', keyPath] );
+			await exec.exec( 'bash', ['-c', 'ssh-add ' + keyPath ] );
+		}
+
+		if( remotePass != '' ) {
+			await exec.exec( 'sudo', ['apt-get', 'install', '-y', 'sshpass'] );
+		}
 	}
 
-	const remotePass = core.getInput( 'env-pass', { required: false } );
-	if( remotePass != '' ) {
-		await exec.exec( 'sudo', ['apt-get', 'install', '-y', 'sshpass'] );
+	// Preflight: validate the provided credentials with a cheap test connection.
+	// This runs on EVERY invocation (independent of run-pre) so auth/connectivity
+	// failures surface here with a clear message instead of a confusing rsync
+	// error mid-deploy. When run-pre=false the setup above was done by an earlier
+	// invocation and persists on the runner, so the test still works.
+	if (
+		core.getInput( 'preflight', { required: false } ) != 'false' &&
+		remoteHost != '' &&
+		( remoteKey != '' || remotePass != '' )
+	) {
+		core.startGroup( 'Validating SSH credentials.' );
+
+		const params = shellParams.split( ' ' ).filter( ( p ) => p !== '' );
+		if ( remotePort != '' ) {
+			params.push( '-p ' + remotePort );
+		}
+		// Fail fast on connection issues and auto-trust the host key (known_hosts
+		// may not have been populated yet when run-pre=false on a first call).
+		params.push( '-o ConnectTimeout=15' );
+		params.push( '-o StrictHostKeyChecking=accept-new' );
+
+		var shell;
+		if ( remotePass != '' ) {
+			// Password auth: feed the password via the SSHPASS env, never the CLI.
+			shell = 'sshpass -e ssh';
+			process.env['SSHPASS'] = remotePass;
+		} else {
+			// Key auth: never fall back to an interactive prompt (would hang).
+			shell = 'ssh';
+			params.push( '-o BatchMode=yes' );
+			// Make sure we point at the agent the setup step started, even when
+			// run-pre=false skipped exporting it into this process.
+			if ( ! process.env['SSH_AUTH_SOCK'] && fs.existsSync( sock ) ) {
+				process.env['SSH_AUTH_SOCK'] = sock;
+			}
+		}
+
+		const target = ( remoteUser != '' ? remoteUser + '@' : '' ) + remoteHost;
+		const command = shell + ' ' + params.join( ' ' ) + ' ' + target + ' true';
+
+		console.log( command );
+
+		const code = await exec.exec( command, [], { ignoreReturnCode: true } );
+
+		if ( code != 0 ) {
+			core.endGroup();
+			core.setFailed(
+				'SSH preflight failed: the provided ' +
+					( remotePass != '' ? 'password' : 'SSH key' ) +
+					' was rejected or the host is unreachable (exit code ' +
+					code +
+					'). Verify the credentials, host, port and that the key is authorized on the target.'
+			);
+			process.exit( code );
+		}
+
+		console.log( 'SSH credentials validated.' );
+		core.endGroup();
 	}
 } )();


### PR DESCRIPTION
## Problem

SSH deployments fail with confusing rsync errors when credentials are wrong/unauthorized or the host is unreachable. The real cause (auth) is buried in rsync output, and key-auth misconfig can hang on an interactive password prompt.

## Change

Credential preflight in **`pre.js`** (the action's pre step), before any rsync / consistency-check work:

- Runs `ssh user@host true` — on **every invocation**, independent of `run-pre`.
- **Both auth methods**: key (ssh-agent, `-o BatchMode=yes` → fail fast, no prompt hang) and password (`sshpass -e`, password via `SSHPASS` env, never logged).
- Reuses `ssh-shell-params` + port so custom options (e.g. `ProxyJump`) are honored; adds `-o ConnectTimeout=15` and `-o StrictHostKeyChecking=accept-new`.
- Failure → `core.setFailed` with a clear key-vs-password message + exit code, then exit.

New `preflight` input (default `'true'`) for opt-out.

## Why pre step + always

`run-pre` only gates credential **setup**. `consistency-check` invokes `action-deploy-ssh` **multiple times**, passing `run-pre=false` on later calls to reuse the agent / known_hosts / sshpass an earlier call left on the runner. The preflight runs independent of `run-pre` (so it fires on every call), and because that setup persists on the runner, the test still works when `run-pre=false`. `accept-new` covers the edge case where known_hosts wasn't populated yet.

## Base branch

Targets **v4** (the consumed major: `saucal/action-deploy-ssh@v4`), not `main` (`main` is stale/behind v4).

## Notes

- No automated tests in repo; validated with `node --check`. Recommend a smoke test (one good-cred run, one bad-cred run) on a downstream workflow before consumers pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)