### PR TITLE
feat: validate remote path deployability in SSH preflight

### DIFF
--- a/pre.js
+++ b/pre.js
@@ -9,6 +9,8 @@
 	const remoteKey = core.getInput( 'env-key', { required: false } );
 	const remotePass = core.getInput( 'env-pass', { required: false } );
 	const shellParams = core.getInput( 'ssh-shell-params', { required: false } );
+	// Strip trailing slashes to match how main.js normalises the remote root.
+	const remoteRoot = core.getInput( 'env-remote-root', { required: false } ).replace( /\/+$/, '' );
 	const sock = '/tmp/ssh_agent.sock';
 
 	// Credential setup is gated by run-pre: when deploy-ssh is invoked multiple
@@ -103,6 +105,42 @@
 		}
 
 		console.log( 'SSH credentials validated.' );
+
+		// Validate that the remote root is deployable: either an existing writable
+		// directory, or (for a first deploy) a path whose parent exists and is
+		// writable so rsync can create the final directory. Catches missing-path /
+		// wrong-permission misconfig here instead of as a confusing rsync error.
+		if ( remoteRoot != '' ) {
+			// Outer single quotes keep this as a single argument to ssh; inner double
+			// quotes handle the remote-side evaluation. dirname runs on the target.
+			const remoteTest =
+				'test -d "' + remoteRoot + '" && test -w "' + remoteRoot + '" || ' +
+				'{ test ! -e "' + remoteRoot + '" && ' +
+				'test -d "$(dirname "' + remoteRoot + '")" && ' +
+				'test -w "$(dirname "' + remoteRoot + '")"; }';
+
+			const pathCommand =
+				shell + ' ' + params.join( ' ' ) + ' ' + target + " '" + remoteTest + "'";
+
+			console.log( pathCommand );
+
+			const pathCode = await exec.exec( pathCommand, [], { ignoreReturnCode: true } );
+
+			if ( pathCode != 0 ) {
+				core.endGroup();
+				core.setFailed(
+					'SSH preflight failed: remote path "' +
+						remoteRoot +
+						'" is not deployable. It must be an existing writable directory, ' +
+						'or (for a first deploy) its parent must exist and be writable so ' +
+						'rsync can create it. Check the path and the deploy user\'s permissions.'
+				);
+				process.exit( pathCode );
+			}
+
+			console.log( 'Remote path validated.' );
+		}
+
 		core.endGroup();
 	}
 } )();


### PR DESCRIPTION
## Problem

The credential preflight (#16) validates SSH auth + connectivity, but **not** the deploy target. If `env-remote-root` doesn't exist or the deploy user can't write to it, rsync still fails later with the confusing error preflight is meant to eliminate.

## Change

After the auth test passes, run a second cheap check that `env-remote-root` is **deployable**, mirroring rsync's actual requirement:

- ✅ existing **writable directory**, **or**
- ✅ (first deploy) path whose **parent exists and is writable** → rsync creates the final dir
- ❌ missing parent (rsync won't create nested dirs without `--mkpath`)
- ❌ target exists but not writable / not a directory

Reuses the same ssh shell/params/target as the auth test, so `ProxyJump`, port, `BatchMode`/`sshpass` all apply. Runs only when `preflight` is enabled and a remote root is set. Hard-fails with a clear, actionable message.

Remote test (single-quoted as one ssh arg; inner double quotes evaluate on the target):
```sh
test -d "$ROOT" && test -w "$ROOT" || { test ! -e "$ROOT" && test -d "$(dirname "$ROOT")" && test -w "$(dirname "$ROOT")"; }
```

## Verification

`node --check` clean. Logic bash-tested against all four cases (existing-writable PASS, first-deploy PASS, nested-missing-parent FAIL, parent-not-writable FAIL).

## Base branch

Targets **v4** (consumed major), on top of the merged #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)