### PR TITLE
fix: SSH preflight path check fails every deploy (arg mangling)

### DIFF
--- a/pre.js
+++ b/pre.js
@@ -58,26 +58,30 @@
 		remoteHost != '' &&
 		( remoteKey != '' || remotePass != '' )
 	) {
-		core.startGroup( 'Validating SSH credentials.' );
+		core.startGroup( 'Validating SSH connection and remote path.' );
 
-		const params = shellParams.split( ' ' ).filter( ( p ) => p !== '' );
-		if ( remotePort != '' ) {
-			params.push( '-p ' + remotePort );
-		}
-		// Fail fast on connection issues and auto-trust the host key (known_hosts
-		// may not have been populated yet when run-pre=false on a first call).
-		params.push( '-o ConnectTimeout=15' );
-		params.push( '-o StrictHostKeyChecking=accept-new' );
+		// Build the ssh invocation as an explicit argv array and call exec.exec in
+		// its array form (tool + args). The string form runs each argument through
+		// @actions/exec's tokenizer, which only honours double quotes and treats
+		// single quotes as literal characters - that would mangle the remote script
+		// below. Array form passes every argument verbatim, so the script reaches
+		// ssh as a single intact argument.
+		//
+		// Note: we deliberately pass the script as one ssh argument rather than
+		// piping it over stdin. sshpass drives ssh through a pty to inject the
+		// password and does not forward our stdin to the remote command, so a
+		// stdin-fed script would break password auth. A single argv element works
+		// for both key and password auth.
+		var tool;
+		const baseArgs = [];
 
-		var shell;
 		if ( remotePass != '' ) {
 			// Password auth: feed the password via the SSHPASS env, never the CLI.
-			shell = 'sshpass -e ssh';
+			tool = 'sshpass';
+			baseArgs.push( '-e', 'ssh' );
 			process.env['SSHPASS'] = remotePass;
 		} else {
-			// Key auth: never fall back to an interactive prompt (would hang).
-			shell = 'ssh';
-			params.push( '-o BatchMode=yes' );
+			tool = 'ssh';
 			// Make sure we point at the agent the setup step started, even when
 			// run-pre=false skipped exporting it into this process.
 			if ( ! process.env['SSH_AUTH_SOCK'] && fs.existsSync( sock ) ) {
@@ -85,62 +89,83 @@
 			}
 		}
 
+		// User-supplied ssh shell params (e.g. ProxyJump), each as its own token.
+		shellParams.split( ' ' ).filter( ( p ) => p !== '' ).forEach( ( p ) => baseArgs.push( p ) );
+		if ( remotePort != '' ) {
+			baseArgs.push( '-p', remotePort );
+		}
+		// Fail fast on connection issues and auto-trust the host key (known_hosts
+		// may not have been populated yet when run-pre=false on a first call).
+		baseArgs.push( '-o', 'ConnectTimeout=15' );
+		baseArgs.push( '-o', 'StrictHostKeyChecking=accept-new' );
+		if ( remotePass == '' ) {
+			// Key auth: never fall back to an interactive prompt (would hang).
+			baseArgs.push( '-o', 'BatchMode=yes' );
+		}
+
 		const target = ( remoteUser != '' ? remoteUser + '@' : '' ) + remoteHost;
-		const command = shell + ' ' + params.join( ' ' ) + ' ' + target + ' true';
+		baseArgs.push( target );
 
-		console.log( command );
+		// Single remote script covering every check. Connecting at all already
+		// proves auth + connectivity; the script then verifies the remote root is
+		// deployable: an existing writable directory, or (for a first deploy) a
+		// path whose parent exists and is writable so rsync can create the final
+		// directory. Distinct exit codes / PREFLIGHT_FAIL lines give a precise
+		// reason. The root is embedded inside a single-quoted assignment (with
+		// single quotes escaped) so any path is safe from remote-shell parsing.
+		const safeRoot = "'" + remoteRoot.replace( /'/g, "'\\''" ) + "'";
+		const script = [
+			'set -u',
+			'root=' + safeRoot,
+			'if [ -n "$root" ]; then',
+			'  if [ -d "$root" ]; then',
+			'    [ -w "$root" ] || { echo "PREFLIGHT_FAIL:remote path exists but is not writable"; exit 11; }',
+			'  elif [ -e "$root" ]; then',
+			'    echo "PREFLIGHT_FAIL:remote path exists but is not a directory"; exit 12',
+			'  else',
+			'    parent=$(dirname "$root")',
+			'    [ -d "$parent" ] || { echo "PREFLIGHT_FAIL:remote path is missing and its parent does not exist"; exit 13; }',
+			'    [ -w "$parent" ] || { echo "PREFLIGHT_FAIL:remote path is missing and its parent is not writable"; exit 14; }',
+			'  fi',
+			'fi',
+			'echo PREFLIGHT_OK',
+		].join( '\n' );
 
-		const code = await exec.exec( command, [], { ignoreReturnCode: true } );
+		const args = baseArgs.concat( [ script ] );
+		console.log( [ tool ].concat( baseArgs ).join( ' ' ) + ' <remote preflight script>' );
+
+		let output = '';
+		const code = await exec.exec( tool, args, {
+			ignoreReturnCode: true,
+			listeners: {
+				stdout: ( data ) => { output += data.toString(); },
+				stderr: ( data ) => { output += data.toString(); },
+			},
+		} );
 
 		if ( code != 0 ) {
 			core.endGroup();
-			core.setFailed(
-				'SSH preflight failed: the provided ' +
-					( remotePass != '' ? 'password' : 'SSH key' ) +
-					' was rejected or the host is unreachable (exit code ' +
-					code +
-					'). Verify the credentials, host, port and that the key is authorized on the target.'
-			);
+			const failMatch = output.match( /PREFLIGHT_FAIL:(.*)/ );
+			if ( failMatch ) {
+				// Reached the remote shell, so auth/connectivity was fine: a check failed.
+				core.setFailed(
+					'SSH preflight failed: ' + failMatch[ 1 ].trim() +
+						' (remote path "' + remoteRoot + '"). Check the path and the ' +
+						'deploy user\'s permissions.'
+				);
+			} else {
+				// Never reached the script: connection or authentication problem.
+				core.setFailed(
+					'SSH preflight failed: could not connect or authenticate to ' + target +
+						' (exit code ' + code + '). The ' +
+						( remotePass != '' ? 'password' : 'SSH key' ) +
+						' was rejected, or the host/port is unreachable.'
+				);
+			}
 			process.exit( code );
 		}
 
-		console.log( 'SSH credentials validated.' );
-
-		// Validate that the remote root is deployable: either an existing writable
-		// directory, or (for a first deploy) a path whose parent exists and is
-		// writable so rsync can create the final directory. Catches missing-path /
-		// wrong-permission misconfig here instead of as a confusing rsync error.
-		if ( remoteRoot != '' ) {
-			// Outer single quotes keep this as a single argument to ssh; inner double
-			// quotes handle the remote-side evaluation. dirname runs on the target.
-			const remoteTest =
-				'test -d "' + remoteRoot + '" && test -w "' + remoteRoot + '" || ' +
-				'{ test ! -e "' + remoteRoot + '" && ' +
-				'test -d "$(dirname "' + remoteRoot + '")" && ' +
-				'test -w "$(dirname "' + remoteRoot + '")"; }';
-
-			const pathCommand =
-				shell + ' ' + params.join( ' ' ) + ' ' + target + " '" + remoteTest + "'";
-
-			console.log( pathCommand );
-
-			const pathCode = await exec.exec( pathCommand, [], { ignoreReturnCode: true } );
-
-			if ( pathCode != 0 ) {
-				core.endGroup();
-				core.setFailed(
-					'SSH preflight failed: remote path "' +
-						remoteRoot +
-						'" is not deployable. It must be an existing writable directory, ' +
-						'or (for a first deploy) its parent must exist and be writable so ' +
-						'rsync can create it. Check the path and the deploy user\'s permissions.'
-				);
-				process.exit( pathCode );
-			}
-
-			console.log( 'Remote path validated.' );
-		}
-
+		console.log( 'SSH connection and remote path validated.' );
 		core.endGroup();
 	}
 } )();


### PR DESCRIPTION
## ⚠️ Regression fix for #17 (already merged into v4)

The remote path check from #17 is **broken in v4 right now** and fails the path check on **every** deploy that has `preflight` enabled and a remote root set.

### Root cause

The remote command was passed to `exec.exec` as a **string**. `@actions/exec`'s tokenizer (`argStringToArray`) only honours double quotes and treats **single quotes as literal characters**. The single-quoted remote command shattered into ~20 tokens (leading `'test`, trailing `}'`), inner double quotes stripped; ssh rejoined them into a string wrapped in one pair of single quotes → the remote shell ran the whole thing as one literal command name → **exit 127, always**.

### Fix + consolidation

- **One ssh call**, running a single POSIX script on the target. Connecting proves auth + connectivity; the script then verifies remote-root deployability (existing writable dir, or first-deploy parent writable).
- Script passed as a **single argv element** (exec array form) — verbatim, no tokenizer. **Not** over stdin: `sshpass` drives ssh through a pty and won't forward stdin, which would break password auth. One argv element works for both.
- Remote root embedded in an **escaped single-quoted assignment** → any path safe (spaces, quotes). Distinct exit codes (11/12/13/14) + `PREFLIGHT_FAIL:<reason>` lines for precise diagnostics; absent marker = connect/auth failure.

### Verification

`node --check` clean. End-to-end against a fake ssh (`NARGS` confirms script = 1 intact arg): all deployability cases return the right exit code; paths with spaces and single quotes handled; empty root → auth-only OK.

⚠️ Still wants a real smoke test (good-cred / bad-cred / bad-path) on a staging target before relying on it — the fake-ssh harness doesn't exercise real sshpass/pty behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)